### PR TITLE
Apply field conversion to arrays

### DIFF
--- a/src/main/scala/Field.scala
+++ b/src/main/scala/Field.scala
@@ -88,7 +88,8 @@ object Field {
     })
   implicit def arrayGetter[T](implicit r: Field[T], m: Manifest[T]) =
     Field[Array[T]]({
-      case a: Array[_] => a.asInstanceOf[Array[T]]
+      case a: Array[_] if m.isInstanceOf[reflect.AnyValManifest[_]] && a.getClass == m.arrayManifest.runtimeClass => a.asInstanceOf[Array[T]]
+      case a: Array[_] => a.flatMap(r.apply _)
       case list: BasicBSONList => list.asScala.flatMap(r.apply _).toArray
     })
 

--- a/src/test/scala/fieldSpec.scala
+++ b/src/test/scala/fieldSpec.scala
@@ -54,6 +54,27 @@ class fieldSpec extends FunSpec with ShouldMatchers with MongoMatchers with Rout
       opt should be('defined)
       opt.get should equal(Array(1,2,3))
     }
+    it("must use Field.apply on array items") {
+      case class F(i: Int)
+      implicit val field = Field[F] { case i: Int => F(i) }
+      val opt = unpack[Array[F]](Array(1,2))
+      opt should be('defined)
+      opt.get should equal(Array(F(1), F(2)))
+    }
+    it("must return array of matching primitive types as is") {
+      val arr = Array(1, 2)
+      val opt = unpack[Array[Int]](arr)
+      opt should be('defined)
+      opt.get should (be theSameInstanceAs arr)
+    }
+    it("must convert array of not-matching primitive types") {
+      import SmartFields.doubleRecoveringGetter
+      val arr = Array(1, 2)
+      val opt = unpack[Array[Double]](arr)
+      opt should be('defined)
+      opt.get should not (be theSameInstanceAs arr)
+      opt.get should equal(Array(1.0, 2.0))
+    }
   }
   describe("Field") {
     it("can be mapped") {


### PR DESCRIPTION
When you want to get `Array[Double]` and you have `Array[Int]` `arrayGetter` just casted one to another, which is wrong, it should apply `Field.apply`.
