### PR TITLE
Report array decoding failure if any item decoding fails

### DIFF
--- a/src/main/scala/Field.scala
+++ b/src/main/scala/Field.scala
@@ -86,22 +86,24 @@ object Field {
       case b: Binary => b.getData
       case a: Array[Byte] => a
     })
-  implicit def arrayGetter[T](implicit r: Field[T], m: Manifest[T]) =
-    Field[Array[T]]({
-      case a: Array[_] if m.isInstanceOf[reflect.AnyValManifest[_]] && a.getClass == m.arrayManifest.runtimeClass => a.asInstanceOf[Array[T]]
-      case a: Array[_] => a.flatMap(r.apply _)
-      case list: BasicBSONList => list.asScala.flatMap(r.apply _).toArray
-    })
+  implicit def arrayGetter[T](implicit r: Field[T], m: Manifest[T]) = new Field[Array[T]] {
+    override def apply(v: Any) = v match {
+      case a: Array[_] if m.isInstanceOf[reflect.AnyValManifest[_]] && a.getClass == m.arrayManifest.runtimeClass => Some(a.asInstanceOf[Array[T]])
+      case a: Array[_] => mergeResults(a.map(r.apply _)).map(_.toArray)
+      case list: BasicBSONList => mergeResults(list.asScala.map(r.apply _)).map(_.toArray)
+    }
+  }
 
   implicit def optionGetter[T](implicit r: Field[T]) =
     new Field[Option[T]] {
       override def apply(o: Any): Option[Option[T]] = Some(r.apply(o))
     }
-  implicit def listGetter[T](implicit r: Field[T]) =
-    Field[List[T]]({
-      case ar: Array[_] => ar.flatMap(r.apply _).toList
-      case list: BasicBSONList => list.asScala.flatMap(r.apply _).toList
-    })
+  implicit def listGetter[T](implicit r: Field[T]) = new Field[List[T]] {
+    override def apply(v: Any) = v match {
+      case ar: Array[_] => mergeResults(ar.map(r.apply _))
+      case list: BasicBSONList => mergeResults(list.asScala.map(r.apply _))
+    }
+  }
   implicit def tuple2Getter[T1,T2](implicit r1: Field[T1], r2: Field[T2]) =
     new Field[Tuple2[T1,T2]] {
       override def apply(o: Any): Option[Tuple2[T1,T2]] =
@@ -111,5 +113,12 @@ object Field {
             yield (v1, v2)
         }
     }
+
+  def mergeResults[T](results: Traversable[Option[T]]): Option[List[T]] = {
+    results.foldLeft[Option[List[T]]](Some(Nil)) { (res, item) =>
+      for (x <- item; xs <- res) yield x :: xs
+    } map (_.reverse)
+  }
+
   // TODO: Field[Map[String,T]]
 }

--- a/src/test/scala/fieldSpec.scala
+++ b/src/test/scala/fieldSpec.scala
@@ -75,11 +75,27 @@ class fieldSpec extends FunSpec with ShouldMatchers with MongoMatchers with Rout
       opt.get should not (be theSameInstanceAs arr)
       opt.get should equal(Array(1.0, 2.0))
     }
+    it("must return None if at least one item conversion failed") {
+      val arr = Array(1, 2.0)
+      val opt = unpack[Array[Int]](arr)
+      opt should be('empty)
+    }
   }
   describe("Field") {
     it("can be mapped") {
       val field = Field.intGetter map (_.toString)
       field(2) should equal(Some("2"))
+    }
+  }
+  describe("mergeResults") {
+    it("converts sequence of Some into Some(sequence)") {
+      Field.mergeResults(Seq(Some(1), Some(2))) should equal(Some(List(1, 2)))
+    }
+    it("converts empty sequence into Some(Nil)") {
+      Field.mergeResults(Seq()) should equal(Some(Nil))
+    }
+    it("returns None if any item is None") {
+      Field.mergeResults(Seq(Some(1), None)) should equal(None)
     }
   }
 }


### PR DESCRIPTION
Currently all array/list items which can't be decoded by Field are simply silently skipped, which is wrong IMHO.
