### PR TITLE
Implemented marshaller/unmarshaller for Map[String, V] that converts …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ homepage := Some(url("https://github.com/osinka/subset2"))
 
 startYear := Some(2013)
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.11.6", "2.10.5")
+crossScalaVersions := Seq("2.11.7", "2.11.6", "2.10.5")
 
 licenses += "Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
 
@@ -19,7 +19,7 @@ description := """MongoDB Document parser combinators and builders"""
 scalacOptions ++= List("-deprecation", "-unchecked", "-feature")
 
 libraryDependencies ++= Seq(
-  "org.mongodb" % "mongo-java-driver" % "3.0.0",
+  "org.mongodb" % "mongo-java-driver" % "3.0.3",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 

--- a/src/main/scala/Field.scala
+++ b/src/main/scala/Field.scala
@@ -143,4 +143,20 @@ object Field {
         case _ => None
       }
   }
+
+  implicit def mapGetter[K, V](implicit tf: Field[(K, V)]) = new Field[Map[K, V]] {
+
+    override def apply(v: Any) = {
+
+      @inline
+      def conv(iter: Iterable[_]) =
+        allOrNone(iter.map(tf(_))).map(_.toMap)
+
+      v match {
+        case ar: Array[_] => conv(ar)
+        case list: BasicBSONList => conv(list.asScala)
+        case _ => None
+      }
+    }
+  }
 }

--- a/src/main/scala/Field.scala
+++ b/src/main/scala/Field.scala
@@ -20,7 +20,7 @@ import org.bson.BasicBSONObject
 import annotation.implicitNotFound
 import java.util.Date
 import java.util.regex.Pattern
-import util.matching.Regex
+import scala.util.matching.Regex
 import org.bson.types.{ObjectId, Binary, Symbol => BsonSymbol}
 import com.mongodb.DBObject
 import scala.collection.JavaConversions._

--- a/src/main/scala/Writable.scala
+++ b/src/main/scala/Writable.scala
@@ -21,7 +21,7 @@ import org.bson.BasicBSONObject
 import annotation.implicitNotFound
 import java.util.Date
 import java.util.regex.Pattern
-import util.matching.Regex
+import scala.util.matching.Regex
 import org.bson.types.{ObjectId, Binary, Symbol => BsonSymbol}
 import com.mongodb.DBObject
 import scala.collection.JavaConversions._
@@ -69,8 +69,8 @@ object BsonWritable {
       override def apply(x: Option[T]): Option[Any] = x.flatMap(w.apply _)
     }
   implicit def seqSetter[T](implicit w: BsonWritable[T]) =
-    new BsonWritable[Traversable[T]] {
-      override def apply(x: Traversable[T]): Option[Any] = Some( x.flatMap(w.apply _).toArray )
+    new BsonWritable[Seq[T]] {
+      override def apply(x: Seq[T]): Option[Any] = Some( x.flatMap(w.apply _).toArray )
     }
   implicit def tuple2Setter[T1,T2](implicit w1: BsonWritable[T1], w2: BsonWritable[T2]) =
     new BsonWritable[Tuple2[T1,T2]] {

--- a/src/main/scala/Writable.scala
+++ b/src/main/scala/Writable.scala
@@ -87,4 +87,13 @@ object BsonWritable {
           }
         }.map(v => new BasicBSONObject(v.toMap))
     }
+  implicit def mapSetter[K, V](implicit kw: BsonWritable[K], vw: BsonWritable[V], tw: BsonWritable[Tuple2[K, V]]) =
+    new BsonWritable[Map[K, V]] {
+      override def apply(x: Map[K, V]): Option[Any] = Some {
+        x.flatMap {
+          case (key, value) =>
+            tw.apply((key, value))
+        }.toArray
+      }
+    }
 }

--- a/src/test/scala/fieldSpec.scala
+++ b/src/test/scala/fieldSpec.scala
@@ -15,6 +15,10 @@
  */
 package com.osinka.subset
 
+import java.util
+
+import org.bson.BasicBSONObject
+import org.bson.types.BasicBSONList
 import org.scalatest.{FunSpec,Matchers,OptionValues}
 
 import com.mongodb.BasicDBList
@@ -88,6 +92,32 @@ class fieldSpec extends FunSpec with Matchers with MongoMatchers with OptionValu
       opt should equal(Some(2 -> "str"))
     }
   }
+  describe("Map reader with String key") {
+    it("must read from BasicBSONObject") {
+      val da = new BasicBSONObject("name1", 1L)
+      da.append("name2", 2L)
+//      val opt = unpack[scala.collection.Map[String, Long]](da)
+//      opt should equal(Some(Map("name1" -> 1L, "name2" -> 2L)))
+    }
+  }
+//  describe("Map reader with any key") {
+//    it("must read from BasicBSONList") {
+//      val da = new BasicBSONList()
+//
+//      val firstItem = new BasicBSONList()
+//      firstItem.put(0, 10L)
+//      firstItem.put(1, "value10")
+//      da.put(0, firstItem)
+//
+//      val secondItem = new BasicBSONList()
+//      secondItem.put(0, 20L)
+//      secondItem.put(1, "value20")
+//      da.put(1, secondItem)
+//
+//      val opt = unpack[Map[Long, String]](da)
+//      opt should equal(Some(Map(10L -> "value10", 20L -> "value20")))
+//    }
+//  }
   describe("Field") {
     it("can be mapped") {
       val field = Field.intGetter map (_.toString)

--- a/src/test/scala/writableSpec.scala
+++ b/src/test/scala/writableSpec.scala
@@ -42,8 +42,8 @@ class writableSpec extends FunSpec with Matchers with MongoMatchers with OptionV
     it("sets non-empty List[T]") {
       pack(List(1,2)).value should equal(Array(1,2))
     }
-    it("sets Iterable[T]") {
-      pack(Iterable(1,2)).value should equal(Array(1,2))
+    it("sets Seq[T]") {
+      pack(Seq(1,2)).value should equal(Array(1,2))
     }
   }
   describe("Tuple writer") {


### PR DESCRIPTION
…map into bson object.

Alexander, unfortunately I couldn't write `writableSpec` test because of ambiguous implicits. Surprisingly marshalling/unmarshalling works correctly in my project.

The error I get is

```
Error:(61, 11) ambiguous implicit values:
 both method mapSetterStringKey in object BsonWritable of type [V](implicit vw: com.osinka.subset.BsonWritable[V])com.osinka.subset.BsonWritable[Map[String,V]]
 and method seqSetter in object BsonWritable of type [T](implicit w: com.osinka.subset.BsonWritable[T])com.osinka.subset.BsonWritable[Traversable[T]]
 match expected type com.osinka.subset.BsonWritable[Map[String,Long]]
      pack(stringToLong) should equal(Some(new BasicBSONObject("key10", 10L)))
          ^
```

Perhaps having `Field` on `Traversable` is too wide.