### PR TITLE
Support for Mongo Java driver 3.0.x, reader&writer for `Map[String,T]` [closes #13]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: scala
+scala:
+- 2.10.5
+- 2.11.7
+jdk:
+- oraclejdk7
+script:
+- sbt -Dfile.encoding=UTF8 -no-colors ++$TRAVIS_SCALA_VERSION test
+cache:
+  directories:
+  - $HOME/.ivy2/cache
+  - $HOME/.sbt/boot/
+notifications:
+  slack:
+    secure: Z8XOOOab7PxM5exXUhgI8chEAHYOXhTtrannBbGBFeWJ+3RWzs04AOA5RHj5Ad8dGqlJ2l5qlAxJvkw4yr5hha65hr8K2Dg42/QpF+8Qke7/I3PuFri6NCQba81yu/Zh2C+uI3kOJER7vMx9PNxYS78yWJWuGE3nIvq21SkpOvE=

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ homepage := Some(url("https://github.com/osinka/subset2"))
 
 startYear := Some(2013)
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
-crossScalaVersions := Seq("2.11.6", "2.10.5")
+crossScalaVersions := Seq("2.11.7", "2.10.5")
 
 licenses += "Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
 
@@ -19,8 +19,8 @@ description := """MongoDB Document parser combinators and builders"""
 scalacOptions ++= List("-deprecation", "-unchecked", "-feature")
 
 libraryDependencies ++= Seq(
-  "org.mongodb" % "mongo-java-driver" % "3.0.0",
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+  "org.mongodb" % "mongo-java-driver" % "3.0.3",
+  "org.scalatest" %% "scalatest" % "2.2.5" % "test"
 )
 
 credentials <+= (version) map { version: String =>

--- a/src/main/scala/Writable.scala
+++ b/src/main/scala/Writable.scala
@@ -65,8 +65,8 @@ object BsonWritable {
       override def apply(x: Option[T]): Option[Any] = x.flatMap(w.apply _)
     }
   implicit def seqSetter[T](implicit w: BsonWritable[T]) =
-    new BsonWritable[Traversable[T]] {
-      override def apply(x: Traversable[T]): Option[Any] = Some( x.flatMap(w.apply _).toArray )
+    new BsonWritable[Seq[T]] {
+      override def apply(x: Seq[T]): Option[Any] = Some( x.flatMap(w.apply _).toArray )
     }
   implicit def tuple2Setter[T1,T2](implicit w1: BsonWritable[T1], w2: BsonWritable[T2]) =
     new BsonWritable[Tuple2[T1,T2]] {
@@ -74,5 +74,9 @@ object BsonWritable {
         for {x1 <- w1.apply(t._1); x2 <- w2.apply(t._2)}
         yield Array(x1,x2)
     }
-  // TODO: BsonWritable[Map[String,T]]
+  implicit def mapSetter[T](implicit w: BsonWritable[T]) =
+    new BsonWritable[Map[String,T]] {
+      override def apply(m: Map[String,T]) =
+        Some( m.foldLeft(DBO.empty) { (dbo,t) => dbo.append(t)(w) } apply() )
+    }
 }

--- a/src/test/scala/fieldSpec.scala
+++ b/src/test/scala/fieldSpec.scala
@@ -88,6 +88,13 @@ class fieldSpec extends FunSpec with Matchers with MongoMatchers with OptionValu
       opt should equal(Some(2 -> "str"))
     }
   }
+  describe("Map reader") {
+    it("must read from DBObject") {
+      val dbo = DBO("a" -> 1, "b" -> 2) ()
+      val opt = unpack[Map[String,Int]](dbo)
+      opt should equal(Some(Map("a" -> 1, "b" -> 2)))
+    }
+  }
   describe("Field") {
     it("can be mapped") {
       val field = Field.intGetter map (_.toString)

--- a/src/test/scala/writableSpec.scala
+++ b/src/test/scala/writableSpec.scala
@@ -42,8 +42,16 @@ class writableSpec extends FunSpec with Matchers with MongoMatchers with OptionV
     it("sets non-empty List[T]") {
       pack(List(1,2)).value should equal(Array(1,2))
     }
-    it("sets Iterable[T]") {
-      pack(Iterable(1,2)).value should equal(Array(1,2))
+    it("sets Seq[T]") {
+      pack(Seq(1,2)).value should equal(Array(1,2))
+    }
+  }
+  describe("Map writer") {
+    it("encodes an empty Map") {
+      pack(Map.empty[String,Int]).value should equal(DBO.empty())
+    }
+    it("encodes a non-empty Map") {
+      pack(Map("a" -> 1, "b" -> 2)).value should equal(DBO("a" -> 1, "b" ->2)())
     }
   }
   describe("Tuple writer") {

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "2.1.5-SNAPSHOT"
+version in ThisBuild := "2.2.0-SNAPSHOT"


### PR DESCRIPTION
A reader & writer for `Map[String,T]` is quite evident part

Compatibility with MongoDB Java driver 3.0.x is a tricky. There are now two alternate hierarchies of BSON structures. There is `BsonDocument` that holds values from `org.bson.Bson*` exclusively. They call it "type-safe" meaning there should be no other values in there. There is also new `Document` and backward-compatible `BasicDBObject` and `DBObject`, they hold good old `org.bson.types.*` as far as I can tell. But this is indirect knowledge I got from the sources and experiments. I need more experiments to make sure we're not breaking anything.

There is also one missing part in "mongo 3.0.x support in subset" – making `DocParser` able to parse at least `Document` objects.